### PR TITLE
Make Moose dependency explicit

### DIFF
--- a/META.json
+++ b/META.json
@@ -38,6 +38,7 @@
       "runtime" : {
          "requires" : {
             "Cache::RedisDB" : "0.09",
+            "Moose" : "2.0",
             "perl" : "5.008005"
          }
       },

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
-requires 'perl', '5.008005';
+requires 'perl',           '5.008005';
 requires 'Cache::RedisDB', '0.09';
+requires 'Moose',          '>= 2.0';
 
 # requires 'Some::Module', 'VERSION';
 


### PR DESCRIPTION
Apparently our upstream package uses Moose but doesn't make that dependency explicit, either.